### PR TITLE
fix: text field trailing icon padding

### DIFF
--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/App.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/App.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.*
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.transitions.SlideTransition
 import com.beepbeep.designSystem.ui.theme.BpTheme
+import org.thechance.common.presentation.login.LoginScreen
 import org.thechance.common.presentation.main.MainContainer
 import org.thechance.common.presentation.resources.ProvideResources
 
@@ -13,7 +14,7 @@ import org.thechance.common.presentation.resources.ProvideResources
 fun App() {
     BpTheme {
         ProvideResources {
-            Navigator(MainContainer) {
+            Navigator(LoginScreen()) {
                 SlideTransition(it)
             }
         }

--- a/design_system/shared/src/commonMain/kotlin/ui/composable/BpTextField.kt
+++ b/design_system/shared/src/commonMain/kotlin/ui/composable/BpTextField.kt
@@ -41,7 +41,7 @@ fun BpTextField(
     text: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    textFieldModifier: Modifier =  Modifier.fillMaxWidth().height(56.dp),
+    textFieldModifier: Modifier = Modifier.fillMaxWidth().height(56.dp),
     hint: String = "",
     keyboardType: KeyboardType = KeyboardType.Text,
     shapeRadius: Shape = RoundedCornerShape(radius.medium),
@@ -78,11 +78,9 @@ fun BpTextField(
             textStyle = typography.body.copy(colors.contentPrimary),
             singleLine = singleLine,
             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-            trailingIcon = {
-                TrailingIcon(keyboardType, isError, showPassword) {
-                    showPassword = !showPassword
-                }
-            },
+            trailingIcon = if (keyboardType == KeyboardType.Password) {
+                { TrailingIcon(showPassword) { showPassword = !showPassword } }
+            } else null,
             visualTransformation = BpVisualTransformation(keyboardType, showPassword),
             isError = isError,
             colors = TextFieldDefaults.outlinedTextFieldColors(
@@ -119,20 +117,17 @@ private fun ContainerColor(isError: Boolean, correctValidation: Boolean): Color 
 
 @Composable
 private fun TrailingIcon(
-    keyboardType: KeyboardType,
-    isError: Boolean,
     showPassword: Boolean,
     togglePasswordVisibility: () -> Unit
 ) {
-    AnimatedVisibility((keyboardType == KeyboardType.Password || keyboardType == KeyboardType.NumberPassword) && !isError) {
-        IconButton(onClick = { togglePasswordVisibility() }) {
-            Icon(
-                imageVector = if (showPassword) Icons.Outlined.VisibilityOff else Icons.Outlined.Visibility,
-                contentDescription = if (showPassword) "Show Password" else "Hide Password",
-                tint = colors.contentTertiary
-            )
-        }
+    IconButton(onClick = { togglePasswordVisibility() }) {
+        Icon(
+            imageVector = if (showPassword) Icons.Outlined.VisibilityOff else Icons.Outlined.Visibility,
+            contentDescription = if (showPassword) "Show Password" else "Hide Password",
+            tint = colors.contentTertiary
+        )
     }
+
 }
 
 @Composable


### PR DESCRIPTION
### fixed
- trailing icon has padding when its not visible
- password icon dissapear in error now it doesn't

![image](https://github.com/TheChance101/beep-beep/assets/58166633/8f9adb7b-0916-476e-9726-111f8f430dd0)
![image](https://github.com/TheChance101/beep-beep/assets/58166633/54292c23-8725-4195-a0bf-97f56df4e001)

