### PR TITLE
dashboard/feature/filters-reset-option

### DIFF
--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/composables/FilterBox.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/composables/FilterBox.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.beepbeep.designSystem.ui.composable.BpOutlinedButton
@@ -54,7 +55,8 @@ private fun FilterBoxHeader(
         modifier = modifier
             .fillMaxWidth()
             .padding(24.kms),
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
             text = title,

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/composables/FilterBox.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/composables/FilterBox.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.beepbeep.designSystem.ui.composable.BpOutlinedButton
 import com.beepbeep.designSystem.ui.composable.BpTransparentButton
 import com.beepbeep.designSystem.ui.theme.Theme
+import org.thechance.common.presentation.composables.modifier.cursorHoverIconHand
 import org.thechance.common.presentation.resources.Resources
 import org.thechance.common.presentation.util.kms
 
@@ -26,7 +27,7 @@ fun FilterBox(
 ) {
     Box(
         modifier = modifier
-            .width(400.kms)
+            .width(450.kms)
             .background(Theme.colors.surface)
             .border(1.dp, Theme.colors.divider)
     ) {
@@ -89,6 +90,7 @@ private fun FilterBoxFooter(
                 .height(32.dp)
                 .weight(1f)
                 .padding(end = 16.kms)
+                .cursorHoverIconHand()
         )
         BpOutlinedButton(
             title = Resources.Strings.save,
@@ -97,6 +99,7 @@ private fun FilterBoxFooter(
             modifier = Modifier
                 .height(32.dp)
                 .weight(3f)
+                .cursorHoverIconHand()
         )
     }
 }

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/composables/FilterBox.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/composables/FilterBox.kt
@@ -1,0 +1,100 @@
+package org.thechance.common.presentation.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.beepbeep.designSystem.ui.composable.BpOutlinedButton
+import com.beepbeep.designSystem.ui.composable.BpTransparentButton
+import com.beepbeep.designSystem.ui.theme.Theme
+import org.thechance.common.presentation.resources.Resources
+import org.thechance.common.presentation.util.kms
+
+@Composable
+fun FilterBox(
+    title: String,
+    onSaveClicked: () -> Unit,
+    onCancelClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+    hasClearAll: Boolean = true,
+    onClearAllClicked: () -> Unit = {},
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .width(400.kms)
+            .background(Theme.colors.surface)
+            .border(1.dp, Theme.colors.divider)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            FilterBoxHeader(
+                title = title,
+                hasClearAll = hasClearAll,
+                onClearAllClicked = onClearAllClicked
+            )
+            content()
+            FilterBoxFooter(onSaveClicked, onCancelClicked)
+        }
+    }
+}
+
+@Composable
+private fun FilterBoxHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    hasClearAll: Boolean = true,
+    onClearAllClicked: () -> Unit = {}
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(24.kms),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = title,
+            style = Theme.typography.headline,
+            color = Theme.colors.contentPrimary
+        )
+        if (hasClearAll) BpTransparentButton(
+            title = Resources.Strings.clearAll,
+            onClick = onClearAllClicked
+        )
+    }
+}
+
+@Composable
+private fun FilterBoxFooter(
+    onSaveClicked: () -> Unit,
+    onCancelClicked: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(24.kms),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        BpTransparentButton(
+            title = Resources.Strings.cancel,
+            onClick = onCancelClicked,
+            modifier = Modifier
+                .height(32.dp)
+                .weight(1f)
+                .padding(end = 16.kms)
+        )
+        BpOutlinedButton(
+            title = Resources.Strings.save,
+            onClick = onSaveClicked,
+            textPadding = PaddingValues(0.dp),
+            modifier = Modifier
+                .height(32.dp)
+                .weight(3f)
+        )
+    }
+}

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/resources/StringResources.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/resources/StringResources.kt
@@ -89,6 +89,9 @@ data class StringResources(
     val supportPermission: String = "Support",
     val deliveryPermission: String = "Delivery",
     val adminPermission: String = "Admin",
+    // endregion overview
+
+    val clearAll: String = "Clear all",
 )
 
 val englishStrings = StringResources()

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/restaurant/RestaurantInteractionListener.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/restaurant/RestaurantInteractionListener.kt
@@ -47,6 +47,8 @@ interface RestaurantInteractionListener : BaseInteractionListener, AddCuisineLis
     fun onClickEditRestaurantMenuItem(restaurant: RestaurantUiState.RestaurantDetailsUiState)
 
     fun onClickDeleteRestaurantMenuItem(restaurant: RestaurantUiState.RestaurantDetailsUiState)
+
+    fun onFilterClearAllClicked()
 }
 
 interface AddCuisineListener {

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/restaurant/RestaurantScreen.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/restaurant/RestaurantScreen.kt
@@ -283,6 +283,7 @@ class RestaurantScreen :
                 expanded = state.restaurantFilterDropdownMenuUiState.isFilterDropdownMenuExpanded,
                 rating = state.restaurantFilterDropdownMenuUiState.filterRating,
                 priceLevel = state.restaurantFilterDropdownMenuUiState.filterPriceLevel,
+                onFilterClearAllClicked = listener::onFilterClearAllClicked,
             )
         }
     }
@@ -297,97 +298,60 @@ class RestaurantScreen :
         expanded: Boolean,
         rating: Double,
         priceLevel: Int,
+        onFilterClearAllClicked: () -> Unit,
     ) {
         BpDropdownMenu(
-            onDismissRequest = onDismissRequest,
             expanded = expanded,
-            shape = RoundedCornerShape(8.kms),
+            onDismissRequest = onDismissRequest,
+            offset = DpOffset.Zero.copy(y = 16.kms),
+            shape = RoundedCornerShape(Theme.radius.medium),
         ) {
-            Column(
-                modifier = Modifier.background(
-                    color = Theme.colors.surface,
-                    shape = RoundedCornerShape(8.kms)
-                )
+            FilterBox(
+                title = Resources.Strings.filter,
+                onSaveClicked = onClickSave,
+                onCancelClicked = onClickCancel,
+                onClearAllClicked = onFilterClearAllClicked,
             ) {
-                Text(
-                    text = Resources.Strings.filter,
-                    style = Theme.typography.headline,
-                    color = Theme.colors.contentPrimary,
-                    modifier = Modifier.padding(
-                        start = 24.kms,
-                        top = 24.kms
+                Column {
+                    Text(
+                        text = Resources.Strings.rating,
+                        style = Theme.typography.title,
+                        color = Theme.colors.contentPrimary,
+                        modifier = Modifier.padding(start = 24.kms, top = 16.kms)
                     )
-                )
-                Text(
-                    text = Resources.Strings.rating,
-                    style = Theme.typography.title,
-                    color = Theme.colors.contentPrimary,
-                    modifier = Modifier.padding(
-                        start = 24.kms,
-                        top = 40.kms
+                    EditableRatingBar(
+                        rating = rating,
+                        count = 5,
+                        selectedIcon = painterResource(Resources.Drawable.starFilled),
+                        halfSelectedIcon = painterResource(Resources.Drawable.starHalfFilled),
+                        notSelectedIcon = painterResource(Resources.Drawable.starOutlined),
+                        iconsSize = 24.kms,
+                        iconsPadding = PaddingValues(horizontal = 8.kms),
+                        modifier = Modifier.fillMaxWidth()
+                            .padding(top = 16.kms)
+                            .background(color = Theme.colors.background)
+                            .padding(horizontal = 24.kms, vertical = 16.kms),
+                        onClick = { onClickRating(it) }
                     )
-                )
-                EditableRatingBar(
-                    rating = rating,
-                    count = 5,
-                    selectedIcon = painterResource(Resources.Drawable.starFilled),
-                    halfSelectedIcon = painterResource(Resources.Drawable.starHalfFilled),
-                    notSelectedIcon = painterResource(Resources.Drawable.starOutlined),
-                    iconsSize = 24.kms,
-                    iconsPadding = PaddingValues(horizontal = 8.kms),
-                    modifier = Modifier.fillMaxWidth()
-                        .padding(top = 16.kms)
-                        .background(color = Theme.colors.background)
-                        .padding(
-                            horizontal = 24.kms,
-                            vertical = 16.kms
-                        ),
-                    onClick = { onClickRating(it) }
-                )
-
-                Text(
-                    text = Resources.Strings.priceLevel,
-                    style = Theme.typography.title,
-                    color = Theme.colors.contentPrimary,
-                    modifier = Modifier.padding(
-                        start = 24.kms,
-                        top = 32.kms
+                    Text(
+                        text = Resources.Strings.priceLevel,
+                        style = Theme.typography.title,
+                        color = Theme.colors.contentPrimary,
+                        modifier = Modifier.padding(start = 24.kms, top = 32.kms)
                     )
-                )
-                EditablePriceBar(
-                    priceLevel = priceLevel,
-                    count = 3,
-                    icon = painterResource(Resources.Drawable.dollarSign),
-                    enabledIconsColor = Theme.colors.success,
-                    disabledIconsColor = Theme.colors.disable,
-                    iconsPadding = PaddingValues(horizontal = 8.kms),
-                    iconsSize = 16.kms,
-                    modifier = Modifier.fillMaxWidth()
-                        .padding(top = 16.kms)
-                        .background(color = Theme.colors.background)
-                        .padding(
-                            horizontal = 24.kms,
-                            vertical = 16.kms
-                        ),
-                    onClick = { onClickPrice(it) }
-                )
-
-                Row(
-                    Modifier.fillMaxWidth().padding(24.kms),
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    BpTransparentButton(
-                        title = Resources.Strings.cancel,
-                        onClick = { onClickCancel(); onDismissRequest() },
-                        modifier = Modifier.padding(end = 16.kms)
-                            .height(32.dp)
-                            .weight(1f)
-                    )
-                    BpOutlinedButton(
-                        title = Resources.Strings.save,
-                        onClick = { onClickSave(); onDismissRequest() },
-                        modifier = Modifier.height(32.dp).weight(3f),
-                        textPadding = PaddingValues(0.dp)
+                    EditablePriceBar(
+                        priceLevel = priceLevel,
+                        count = 3,
+                        icon = painterResource(Resources.Drawable.dollarSign),
+                        enabledIconsColor = Theme.colors.success,
+                        disabledIconsColor = Theme.colors.disable,
+                        iconsPadding = PaddingValues(horizontal = 8.kms),
+                        iconsSize = 16.kms,
+                        modifier = Modifier.fillMaxWidth()
+                            .padding(top = 16.kms)
+                            .background(color = Theme.colors.background)
+                            .padding(horizontal = 24.kms, vertical = 16.kms),
+                        onClick = { onClickPrice(it) }
                     )
                 }
             }

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/restaurant/RestaurantScreenModel.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/restaurant/RestaurantScreenModel.kt
@@ -88,6 +88,7 @@ class RestaurantScreenModel(
             )
         }
         getRestaurants()
+        onDismissDropDownMenu()
     }
 
     override fun onCancelFilterRestaurantsClicked() {
@@ -101,6 +102,7 @@ class RestaurantScreenModel(
             )
         }
         getRestaurants()
+        onDismissDropDownMenu()
     }
 
 
@@ -252,6 +254,18 @@ class RestaurantScreenModel(
         )
     }
 
+    override fun onFilterClearAllClicked() {
+        updateState {
+            it.copy(
+                restaurantFilterDropdownMenuUiState = it.restaurantFilterDropdownMenuUiState.copy(
+                    filterRating = 0.0,
+                    filterPriceLevel = 1,
+                    isFiltered = false
+                )
+            )
+        }
+    }
+
     override fun onCreateNewRestaurantClicked() {
         tryToExecute(
             callee = {
@@ -276,7 +290,6 @@ class RestaurantScreenModel(
         updateState { it.copy(restaurants = restaurants, isLoading = false) }
         hideEditRestaurantMenu()
     }
-
 
 
     // region Cuisine Dialog

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/restaurant/RestaurantScreenModel.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/restaurant/RestaurantScreenModel.kt
@@ -92,16 +92,6 @@ class RestaurantScreenModel(
     }
 
     override fun onCancelFilterRestaurantsClicked() {
-        updateState {
-            it.copy(
-                restaurantFilterDropdownMenuUiState = it.restaurantFilterDropdownMenuUiState.copy(
-                    filterRating = 0.0,
-                    filterPriceLevel = 1,
-                    isFiltered = false
-                )
-            )
-        }
-        getRestaurants()
         onDismissDropDownMenu()
     }
 

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/taxi/TaxiInteractionListener.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/taxi/TaxiInteractionListener.kt
@@ -8,9 +8,11 @@ interface TaxiInteractionListener : BaseInteractionListener, FilterMenuListener,
     TaxiMenuListener, PageListener, TaxiDialogListener {
 
     fun onExportReportClicked()
+
     fun onDismissExportReportSnackBar()
 
     fun onSearchInputChange(searchQuery: String)
+
     fun onAddNewTaxiClicked()
 }
 
@@ -25,32 +27,45 @@ interface TaxiDialogListener {
     fun onCarColorSelected(color: CarColor)
 
     fun onSeatSelected(seats: Int)
+
     fun onSaveClicked()
+
     fun onCancelClicked()
+
     fun onCreateTaxiClicked()
 }
 
 interface TaxiMenuListener {
+
     fun showTaxiMenu(taxiId: String)
+
     fun hideTaxiMenu()
+
     fun onDeleteTaxiClicked(taxi: String)
+
     fun onEditTaxiClicked(taxi: TaxiDetailsUiState)
 }
 
 interface FilterMenuListener {
-
     fun onCancelFilterClicked()
+
     fun onSaveFilterClicked()
+
     fun onFilterMenuDismiss()
+
     fun onFilterMenuClicked()
 
     fun onSelectedCarColor(color: CarColor)
 
     fun onSelectedSeat(seats: Int)
+
     fun onSelectedStatus(status: TaxiStatus)
+
+    fun onClearAllClicked()
 }
 
 interface PageListener {
     fun onItemsIndicatorChange(itemPerPage: Int)
+
     fun onPageClick(pageNumber: Int)
 }

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/taxi/TaxiScreen.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/taxi/TaxiScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -22,7 +21,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import cafe.adriel.voyager.navigator.Navigator
 import com.beepbeep.designSystem.ui.composable.*
@@ -109,6 +107,7 @@ class TaxiScreen :
                             onStatusSelected = listener::onSelectedStatus,
                             onSaveFilterClicked = listener::onSaveFilterClicked,
                             onCancelFilterClicked = listener::onCancelFilterClicked,
+                            onClearAllClicked = listener::onClearAllClicked,
                         )
                     }
                     Spacer(modifier = Modifier.weight(1f))
@@ -183,6 +182,7 @@ class TaxiScreen :
             }
         }
     }
+
     //region components
 
     @Composable
@@ -195,99 +195,69 @@ class TaxiScreen :
         onStatusSelected: (TaxiStatus) -> Unit,
         onSaveFilterClicked: () -> Unit,
         onCancelFilterClicked: () -> Unit,
+        onClearAllClicked: () -> Unit,
     ) {
         BpDropdownMenu(
             expanded = isFilterDropdownMenuExpanded,
             onDismissRequest = onFilterMenuDismiss,
             offset = DpOffset.Zero.copy(y = 16.kms),
-            shape = RoundedCornerShape(Theme.radius.medium).copy(topStart = CornerSize(Theme.radius.small)),
-            modifier = Modifier.width(500.kms),
+            shape = RoundedCornerShape(Theme.radius.medium),
         ) {
-            Column(Modifier.fillMaxSize()) {
-                Text(
-                    Resources.Strings.filter,
-                    style = Theme.typography.headline,
-                    color = Theme.colors.contentPrimary,
-                    modifier = Modifier.padding(24.kms)
-                )
-                Text(
-                    Resources.Strings.status,
-                    style = Theme.typography.titleLarge,
-                    color = Theme.colors.contentPrimary,
-                    modifier = Modifier
-                        .padding(
-                            horizontal = 24.kms,
-                            vertical = 16.kms
-                        ),
-                )
-                CarStatus(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(color = Theme.colors.background)
-                        .padding(24.kms),
-                    status = TaxiStatus.values().toList(),
-                    onSelectState = onStatusSelected,
-                    selectedStatus = taxi.status,
-                )
-
-                Text(
-                    Resources.Strings.carColor,
-                    style = Theme.typography.titleLarge,
-                    color = Theme.colors.contentPrimary,
-                    modifier = Modifier.padding(
-                        horizontal = 24.kms,
-                        vertical = 16.kms
-                    ),
-                )
-                CarColors(
-                    modifier = Modifier.fillMaxWidth()
-                        .background(color = Theme.colors.background).padding(
-                            horizontal = 24.kms,
-                            vertical = 16.kms
-                        ),
-                    colors = CarColor.values().toList(),
-                    onSelectColor = onCarColorSelected,
-                    selectedCarColor = taxi.carColor
-                )
-                Text(
-                    Resources.Strings.seats,
-                    style = Theme.typography.titleLarge,
-                    color = Theme.colors.contentPrimary,
-                    modifier = Modifier.padding(
-                        horizontal = 24.kms,
-                        vertical = 16.kms
+            FilterBox(
+                title = Resources.Strings.filter,
+                onSaveClicked = onSaveFilterClicked,
+                onCancelClicked = onCancelFilterClicked,
+                onClearAllClicked = onClearAllClicked,
+            ) {
+                Column(Modifier.fillMaxSize()) {
+                    Text(
+                        Resources.Strings.status,
+                        style = Theme.typography.titleLarge,
+                        color = Theme.colors.contentPrimary,
+                        modifier = Modifier.padding(horizontal = 24.kms, vertical = 16.kms),
                     )
-                )
-                SeatsBar(
-                    selectedSeatsCount = taxi.seats,
-                    count = 6,
-                    selectedIcon = painterResource(Resources.Drawable.seatFilled),
-                    notSelectedIcon = painterResource(Resources.Drawable.seatOutlined),
-                    iconsSize = 24.kms,
-                    iconsPadding = PaddingValues(horizontal = 8.kms),
-                    modifier = Modifier.fillMaxWidth()
-                        .background(color = Theme.colors.background).padding(
-                            horizontal = 24.kms,
-                            vertical = 16.kms
-                        ),
-                    onClick = onSeatsSelected
-                )
-                Row(
-                    Modifier.padding(24.kms),
-                    horizontalArrangement = Arrangement.spacedBy(16.kms),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    BpTransparentButton(
-                        title = Resources.Strings.cancel,
-                        onClick = onCancelFilterClicked,
-                        modifier = Modifier.cursorHoverIconHand()
-
+                    CarStatus(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(color = Theme.colors.background)
+                            .padding(24.kms),
+                        status = TaxiStatus.values().toList(),
+                        onSelectState = onStatusSelected,
+                        selectedStatus = taxi.status,
                     )
-                    BpOutlinedButton(
-                        title = Resources.Strings.save,
-                        onClick = onSaveFilterClicked,
-                        shape = RoundedCornerShape(Theme.radius.small),
-                        modifier = Modifier.height(50.dp).weight(1f)
+                    Text(
+                        Resources.Strings.carColor,
+                        style = Theme.typography.titleLarge,
+                        color = Theme.colors.contentPrimary,
+                        modifier = Modifier.padding(horizontal = 24.kms, vertical = 16.kms),
+                    )
+                    CarColors(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(color = Theme.colors.background)
+                            .padding(horizontal = 24.kms, vertical = 16.kms),
+                        colors = CarColor.values().toList(),
+                        onSelectColor = onCarColorSelected,
+                        selectedCarColor = taxi.carColor
+                    )
+                    Text(
+                        Resources.Strings.seats,
+                        style = Theme.typography.titleLarge,
+                        color = Theme.colors.contentPrimary,
+                        modifier = Modifier.padding(horizontal = 24.kms, vertical = 16.kms)
+                    )
+                    SeatsBar(
+                        selectedSeatsCount = taxi.seats,
+                        count = 6,
+                        selectedIcon = painterResource(Resources.Drawable.seatFilled),
+                        notSelectedIcon = painterResource(Resources.Drawable.seatOutlined),
+                        iconsSize = 24.kms,
+                        iconsPadding = PaddingValues(horizontal = 8.kms),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(color = Theme.colors.background)
+                            .padding(horizontal = 24.kms, vertical = 16.kms),
+                        onClick = onSeatsSelected
                     )
                 }
             }

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/taxi/TaxiScreenModel.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/taxi/TaxiScreenModel.kt
@@ -202,10 +202,9 @@ class TaxiScreenModel(
         }
     }
 
-    override fun onCancelFilterClicked() {
+    override fun onClearAllClicked() {
         updateState {
             it.copy(
-                isFilterDropdownMenuExpanded = false,
                 taxiFilterUiState = TaxiFilterUiState(
                     carColor = null,
                     seats = -1,
@@ -213,7 +212,10 @@ class TaxiScreenModel(
                 )
             )
         }
-        getTaxis()
+    }
+
+    override fun onCancelFilterClicked() {
+        onFilterMenuDismiss()
     }
 
     override fun onSaveFilterClicked() {

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/users/UserInteractionListener.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/users/UserInteractionListener.kt
@@ -23,6 +23,7 @@ interface FilterMenuListener {
     fun onFilterMenuPermissionClick(permission: UserScreenUiState.PermissionUiState)
     fun onFilterMenuCountryClick(country: UserScreenUiState.CountryUiState)
     fun onFilterMenuSaveButtonClicked()
+    fun onFilterClearAllClicked()
 }
 
 interface PageListener {

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/users/UserScreen.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/users/UserScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,10 +20,7 @@ import cafe.adriel.voyager.navigator.Navigator
 import com.beepbeep.designSystem.ui.composable.*
 import com.beepbeep.designSystem.ui.theme.Theme
 import org.thechance.common.presentation.base.BaseScreen
-import org.thechance.common.presentation.composables.BpDropdownMenu
-import org.thechance.common.presentation.composables.BpDropdownMenuItem
-import org.thechance.common.presentation.composables.PermissionsDialog
-import org.thechance.common.presentation.composables.PermissionsFlowRow
+import org.thechance.common.presentation.composables.*
 import org.thechance.common.presentation.composables.modifier.cursorHoverIconHand
 import org.thechance.common.presentation.composables.modifier.noRipple
 import org.thechance.common.presentation.composables.table.BpPager
@@ -96,6 +92,7 @@ class UserScreen : BaseScreen<UserScreenModel, UserUiEffect, UserScreenUiState, 
                     onFilterMenuClicked = filterMenuListener::showFilterMenu,
                     onFilterMenuDismiss = filterMenuListener::hideFilterMenu,
                     onFilterSaved = filterMenuListener::onFilterMenuSaveButtonClicked,
+                    onFilterClearAllClicked = filterMenuListener::onFilterClearAllClicked,
                 )
 
                 UsersTable(
@@ -320,6 +317,7 @@ class UserScreen : BaseScreen<UserScreenModel, UserUiEffect, UserScreenUiState, 
     }
 
     //endregion
+
     @Composable
     private fun UsersFilterDropdownMenu(
         isFilterDropdownMenuExpanded: Boolean,
@@ -330,7 +328,8 @@ class UserScreen : BaseScreen<UserScreenModel, UserUiEffect, UserScreenUiState, 
         onFilterCountryClicked: (UserScreenUiState.CountryUiState) -> Unit,
         onFilterMenuClicked: () -> Unit,
         onFilterMenuDismiss: () -> Unit,
-        onFilterSaved: () -> Unit
+        onFilterSaved: () -> Unit,
+        onFilterClearAllClicked: () -> Unit,
     ) {
         Row {
             BpIconButton(
@@ -348,88 +347,50 @@ class UserScreen : BaseScreen<UserScreenModel, UserUiEffect, UserScreenUiState, 
                 expanded = isFilterDropdownMenuExpanded,
                 onDismissRequest = onFilterMenuDismiss,
                 offset = DpOffset.Zero.copy(y = 16.kms),
-                shape = RoundedCornerShape(Theme.radius.medium).copy(topStart = CornerSize(Theme.radius.small)),
-                modifier = Modifier.height(450.kms)
+                shape = RoundedCornerShape(Theme.radius.medium),
+                modifier = Modifier.height(600.kms)
             ) {
-                DropdownMenuItem(
-                    contentPadding = PaddingValues(0.dp),
-                    modifier = Modifier.width(400.kms),
-                    onClick = {},
-                    text = {
-                        Column(Modifier.fillMaxSize()) {
-                            Text(
-                                text = Resources.Strings.filter,
-                                style = Theme.typography.headline,
-                                color = Theme.colors.contentPrimary,
-                                modifier = Modifier.padding(
-                                    start = 24.kms,
-                                    top = 24.kms
-                                )
-                            )
-                            Text(
-                                text = Resources.Strings.permission,
-                                style = Theme.typography.titleLarge,
-                                color = Theme.colors.contentPrimary,
-                                modifier = Modifier.padding(
-                                    start = 24.kms,
-                                    top = 40.kms,
-                                    bottom = 16.kms
-                                ),
-                            )
-                            PermissionsFlowRow(
-                                allPermissions = allPermissions,
-                                selectedPermissions = selectedPermissions,
-                                onUserPermissionClicked = onFilterPermissionClicked
-                            )
-                            Text(
-                                text = Resources.Strings.country,
-                                style = Theme.typography.titleLarge,
-                                color = Theme.colors.contentPrimary,
-                                modifier = Modifier.padding(
-                                    start = 24.kms,
-                                    top = 32.kms,
-                                    bottom = 16.kms
-                                )
-                            )
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .background(Theme.colors.background)
-                                    .padding(
-                                        horizontal = 24.kms,
-                                        vertical = 16.kms
-                                    ),
-                                verticalArrangement = Arrangement.spacedBy(16.kms)
-                            ) {
-                                countries.forEach { country ->
-                                    BpCheckBox(
-                                        label = country.name,
-                                        onCheck = { onFilterCountryClicked(country) },
-                                        isChecked = country.selected
-                                    )
-                                }
-                            }
-                            Row(
-                                Modifier.padding(24.kms),
-                                horizontalArrangement = Arrangement.spacedBy(16.kms),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                BpTransparentButton(
-                                    title = Resources.Strings.cancel,
-                                    onClick = onFilterMenuDismiss,
-                                    modifier = Modifier.cursorHoverIconHand()
-
-                                )
-                                BpOutlinedButton(
-                                    title = Resources.Strings.save,
-                                    onClick = onFilterSaved,
-                                    shape = RoundedCornerShape(Theme.radius.small),
-                                    modifier = Modifier.weight(1f)
+                FilterBox(
+                    title = Resources.Strings.filter,
+                    onSaveClicked = onFilterSaved,
+                    onCancelClicked = onFilterMenuDismiss,
+                    onClearAllClicked = onFilterClearAllClicked,
+                ) {
+                    Column {
+                        Text(
+                            text = Resources.Strings.permission,
+                            style = Theme.typography.titleLarge,
+                            color = Theme.colors.contentPrimary,
+                            modifier = Modifier.padding(start = 24.kms, top = 16.kms, bottom = 16.kms),
+                        )
+                        PermissionsFlowRow(
+                            allPermissions = allPermissions,
+                            selectedPermissions = selectedPermissions,
+                            onUserPermissionClicked = onFilterPermissionClicked
+                        )
+                        Text(
+                            text = Resources.Strings.country,
+                            style = Theme.typography.titleLarge,
+                            color = Theme.colors.contentPrimary,
+                            modifier = Modifier.padding(start = 24.kms, top = 32.kms, bottom = 16.kms)
+                        )
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(Theme.colors.background)
+                                .padding(horizontal = 24.kms, vertical = 16.kms),
+                            verticalArrangement = Arrangement.spacedBy(16.kms)
+                        ) {
+                            countries.forEach { country ->
+                                BpCheckBox(
+                                    label = country.name,
+                                    onCheck = { onFilterCountryClicked(country) },
+                                    isChecked = country.selected
                                 )
                             }
                         }
                     }
-                )
+                }
             }
         }
     }
@@ -447,6 +408,7 @@ class UserScreen : BaseScreen<UserScreenModel, UserUiEffect, UserScreenUiState, 
         onFilterMenuClicked: () -> Unit,
         onFilterMenuDismiss: () -> Unit,
         onFilterSaved: () -> Unit,
+        onFilterClearAllClicked: () -> Unit,
     ) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(bottom = 16.kms),
@@ -471,7 +433,8 @@ class UserScreen : BaseScreen<UserScreenModel, UserUiEffect, UserScreenUiState, 
                 onFilterCountryClicked = onFilterCountryClicked,
                 onFilterMenuClicked = onFilterMenuClicked,
                 onFilterMenuDismiss = onFilterMenuDismiss,
-                onFilterSaved = onFilterSaved
+                onFilterSaved = onFilterSaved,
+                onFilterClearAllClicked = onFilterClearAllClicked
             )
         }
     }

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/users/UserScreenModel.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/users/UserScreenModel.kt
@@ -58,6 +58,17 @@ class UserScreenModel(
         getUsers()
     }
 
+    override fun onFilterClearAllClicked() {
+        updateState {
+            it.copy(
+                filter = it.filter.copy(
+                    permissions = emptyList(),
+                    countries = it.filter.countries.map { country -> country.copy(selected = false) }
+                )
+            )
+        }
+    }
+
     // endregion
 
     // region Search Bar


### PR DESCRIPTION
Ensure that all filter dialogs include a 'Clear All' option to reset the filter selections. Additionally, resolve the issue where the entire dialog is clickable.

![java_zUrWiWsc0s](https://github.com/TheChance101/beep-beep/assets/64174395/5a1bd047-905c-455f-930c-15a01231ae72)
