### PR TITLE
dashboard/fix/snackbar_in_login

### DIFF
--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/composables/table/BpTable.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/composables/table/BpTable.kt
@@ -124,7 +124,7 @@ private fun TableRowLoading(
         val randomFloat= remember { (50..100).random().dp }
         repeat(9) {
             Box(modifier = Modifier.weight(if (it == 0 || it == 8) 1f else 3f)){
-                Box(modifier = Modifier.height(30.kms).width(randomFloat)
+                Box(modifier = Modifier.height(30.kms).width(randomFloat).align(Alignment.CenterStart)
                     .clip(shape = RoundedCornerShape(4.dp)).shimmerEffect(durationMillis = 1500))
             }
         }

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/login/LoginScreen.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/login/LoginScreen.kt
@@ -154,7 +154,7 @@ class LoginScreen :
                         title = Resources.Strings.loginButton,
                         onClick = { listener.onLoginClicked() },
                         modifier = Modifier.padding(top = 24.kms).fillMaxWidth(),
-                        enabled = state.isAbleToLogin,
+                        enabled = state.isEnable,
                         isLoading = state.isLoading,
                     )
                 }

--- a/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/login/LoginUIState.kt
+++ b/client_dashboard/common/src/commonMain/kotlin/org/thechance/common/presentation/login/LoginUIState.kt
@@ -9,7 +9,7 @@ data class LoginUIState(
     val isLoading: Boolean = false,
     val isUserError: ErrorWrapper? = null,
     val isPasswordError: ErrorWrapper? = null,
-    val isAbleToLogin: Boolean = false,
+    val isEnable: Boolean = false,
     val snackBarTitle: String? = null,
     val isSnackBarVisible: Boolean = false
 )


### PR DESCRIPTION
-fix padding in shimmerEffect that in table 
-fix snackbar behavior , when error state is be invalid password or invalid username what happen is show snackbar and this is not correct behavior